### PR TITLE
updates the `anonymization` dependency to v1.4.x

### DIFF
--- a/.github/workflows/go-pkg.yml
+++ b/.github/workflows/go-pkg.yml
@@ -22,6 +22,9 @@ jobs:
         # Bring in everything...
         fetch-depth: '0'
     
+    - name: update ubuntu 
+      run: sudo apt-get update
+    
     - name: Install make
       run: sudo apt-get install make
     

--- a/beater/sipcmbeat.go
+++ b/beater/sipcmbeat.go
@@ -7,12 +7,9 @@
 package beater
 
 import (
-	"encoding/hex"
 	"fmt"
 	"strconv"
 	//	"runtime/pprof"
-	"crypto"
-	"crypto/subtle"
 	"net"
 	"reflect"
 	"strings"
@@ -237,10 +234,9 @@ type Sipcmbeat struct {
 
 	pStatsInfo publishStatsInfo // stats event publish internal stuff
 
-	Config    sipcallmon.Config
-	ipcipher  *anonymization.Ipcipher
-	validator anonymization.Validator
-	client    beat.Client
+	Config     sipcallmon.Config
+	anonymizer anonymization.Anonymizer
+	client     beat.Client
 	// stats
 	stats   counters.Group
 	cnts    statCounters
@@ -399,8 +395,6 @@ func keystoreVal(b *beat.Beat, key string) (string, error) {
 }
 
 func (bt *Sipcmbeat) initEncryption(b *beat.Beat) error {
-	var encKey [anonymization.EncryptionKeyLen]byte
-	var authKey [anonymization.AuthenticationKeyLen]byte
 	const ksPrefix = "keystore:"
 
 	salt := bt.Config.EncryptionValSalt
@@ -417,7 +411,7 @@ func (bt *Sipcmbeat) initEncryption(b *beat.Beat) error {
 		}
 	}
 	if len(bt.Config.EncryptionPassphrase) > 0 {
-		// generate encryption key from passphrase
+		// generate all keys from passphrase
 		pass := bt.Config.EncryptionPassphrase
 		if len(pass) >= len(ksPrefix) && strings.HasPrefix(pass, ksPrefix) {
 			// starts with the keystore prefix -> look for the pass in the
@@ -428,9 +422,9 @@ func (bt *Sipcmbeat) initEncryption(b *beat.Beat) error {
 				return errors.WithMessage(err, "initEncryption: passphrase")
 			}
 		}
-		anonymization.GenerateKeyFromPassphraseAndCopy(pass,
-			anonymization.EncryptionKeyLen, encKey[:])
+		anonymization.GenerateAllKeysWithPassphrase(pass)
 	} else {
+		// generate all keys from master key
 		cfgKey := bt.Config.EncryptionKey
 		if len(cfgKey) >= len(ksPrefix) && strings.HasPrefix(cfgKey, ksPrefix) {
 			// starts with the keystore prefix -> look for the key in the
@@ -441,40 +435,14 @@ func (bt *Sipcmbeat) initEncryption(b *beat.Beat) error {
 				return errors.WithMessage(err, "initEncryption: key")
 			}
 		}
-		// copy the configured key into the one used during realtime processing
-		if decoded, err := hex.DecodeString(cfgKey); err != nil {
+		// decode the hex encoded master key
+		if err := anonymization.GenerateAllKeysWithHexMasterKey(cfgKey); err != nil {
 			return err
-		} else {
-			subtle.ConstantTimeCopy(1, encKey[:], decoded)
 		}
 	}
-
-	// generate authentication (HMAC) key from encryption key
-	anonymization.GenerateKeyFromBytesAndCopy(encKey[:], anonymization.AuthenticationKeyLen, authKey[:])
-	// validation code is the first 5 bytes of HMAC(SHA256) of random nonce; each thread needs its own validator!
-	if validator, err := anonymization.NewKeyValidator(crypto.SHA256, authKey[:],
-		5 /*length*/, salt, anonymization.NonceNone, false /*withNonce*/, true /*pre-allocated HMAC*/); err != nil {
+	if _, err := bt.anonymizer.UpdateKeys(anonymization.Keys[:]); err != nil {
 		return err
-	} else {
-		bt.validator = validator
 	}
-
-	if ipcipher, err := anonymization.NewCipher(encKey[:]); err != nil {
-		return err
-	} else {
-		bt.ipcipher = ipcipher.(*anonymization.Ipcipher)
-	}
-
-	// initialize the IP Prefix-preserving anonymization
-	_ = anonymization.NewPanIPv4(encKey[:])
-
-	// initialize the URI CBC based encryption
-	anonymization.InitUriKeysFromMasterKey(encKey[:])
-	_ = anonymization.NewUriCBC(anonymization.GetUriKeys())
-
-	// initialize the Call-ID CBC based encryption
-	anonymization.InitCallIdKeysFromMasterKey(encKey[:])
-	_ = anonymization.NewCallIdCBC(anonymization.GetCallIdKeys())
 
 	return nil
 }
@@ -742,16 +710,15 @@ func (bt *Sipcmbeat) getCallID(dst, src []byte, callID sipsp.PField, encFlags *F
 	if bt.Config.UseCallIDAnonymization() && (len(src) > 0) {
 		// anonymize Call-ID
 		//anonymization.DbgOn()
-		ac := anonymization.AnonymPField{
-			PField: callID,
-		}
-		if err := ac.Anonymize(dst, src); err != nil {
+		bt.anonymizer.CallId.PField = callID
+		aCallId, err := bt.anonymizer.CallId.Anonymize(dst, src)
+		if err != nil {
 			return nil, fmt.Errorf("Call-ID field processing error: %w", err)
 		}
 		if encFlags != nil {
 			*encFlags |= FormatCallIDencF
 		}
-		return ac.PField.Get(dst), nil
+		return aCallId, nil
 	}
 	// pass through
 	return callID.Get(src), nil
@@ -771,16 +738,15 @@ func (bt *Sipcmbeat) getEncContent(
 
 	if bt.Config.UseAnonymization() && (len(src) > 0) {
 		// anonymize src, the same way as Call-ID
-		ac := anonymization.AnonymPField{
-			PField: content,
-		}
-		if err := ac.Anonymize(dst, src); err != nil {
+		bt.anonymizer.CallId.PField = content
+		aContent, err := bt.anonymizer.CallId.Anonymize(dst, src)
+		if err != nil {
 			return nil, false,
 				fmt.Errorf("field content processing error: %w", err)
 		}
 		// ac.Anonymize above will change ac.PField to point to the enc
 		// version
-		return ac.PField.Get(dst), true, nil
+		return aContent, true, nil
 	}
 	// pass through
 	return content.Get(src), false, nil
@@ -794,20 +760,15 @@ func (bt *Sipcmbeat) getURI(attr calltr.CallAttrIdx, dst, src []byte,
 			// pass through
 			return src[:], nil
 		}
-		// anonymize URI
-		var uri sipsp.PsipURI
-		if err, _ := sipsp.ParseURI(src, &uri); err != 0 {
-			return nil, err
-		}
-		//anonymization.DbgOn()
-		au := anonymization.AnonymURI(uri)
-		if err := au.Anonymize(dst, src, true); err != nil {
+		// anonymize URI _including_ parameters
+		aUri, err := bt.anonymizer.Uri.Anonymize(dst, src)
+		if err != nil {
 			return nil, err
 		}
 		if encFlags != nil {
 			*encFlags |= FormatURIencF
 		}
-		return (*sipsp.PsipURI)(&au).Flat(dst), nil
+		return aUri, nil
 	}
 	// pass through
 	return src[:], nil
@@ -821,12 +782,12 @@ func (bt *Sipcmbeat) getSrcIP(ed *calltr.EventData, encFlags *FormatFlags) net.I
 			*encFlags |= FormatCltIPencF
 		}
 		if bt.Config.UseIpcipher() || ed.Src.To4() == nil {
-			bt.ipcipher.Encrypt(c, ed.Src)
+			bt.anonymizer.Ipcipher.Encrypt(c, ed.Src)
 			if encFlags != nil {
 				*encFlags |= FormatIpcipherF
 			}
 		} else {
-			anonymization.GetPan4().Encrypt(c, ed.Src)
+			bt.anonymizer.Pan.Encrypt(c, ed.Src)
 		}
 		return net.IP(c[:])
 	}
@@ -841,12 +802,12 @@ func (bt *Sipcmbeat) getDstIP(ed *calltr.EventData, encFlags *FormatFlags) net.I
 			*encFlags |= FormatSrvIPencF
 		}
 		if bt.Config.UseIpcipher() || ed.Dst.To4() == nil {
-			bt.ipcipher.Encrypt(c, ed.Dst)
+			bt.anonymizer.Ipcipher.Encrypt(c, ed.Dst)
 			if encFlags != nil {
 				*encFlags |= FormatIpcipherF
 			}
 		} else {
-			anonymization.GetPan4().Encrypt(c, ed.Dst)
+			bt.anonymizer.Pan.Encrypt(c, ed.Dst)
 		}
 		return net.IP(c[:])
 	}
@@ -1188,10 +1149,10 @@ add_attrs:
 
 	// encrypted flags
 	if encFlags != 0 {
-		if bt.validator != nil {
+		if bt.anonymizer.Validator != nil {
 			// the precomputed validation code cand be used as long nonce is NOT used
 			addFields(event.Fields, "encrypt_flags", strconv.Itoa(int(encFlags)))
-			addFields(event.Fields, "encrypt", bt.validator.Code())
+			addFields(event.Fields, "encrypt", bt.anonymizer.Validator.Code())
 		}
 	} else {
 		addFields(event.Fields, "encrypt_flags", "0")

--- a/beater/sipcmbeat.go
+++ b/beater/sipcmbeat.go
@@ -440,6 +440,11 @@ func (bt *Sipcmbeat) initEncryption(b *beat.Beat) error {
 			return err
 		}
 	}
+	anonymizer, err := anonymization.NewAnonymizer(salt)
+	if err != nil {
+		return err
+	}
+	bt.anonymizer = *anonymizer
 	if _, err := bt.anonymizer.UpdateKeys(anonymization.Keys[:]); err != nil {
 		return err
 	}
@@ -710,7 +715,7 @@ func (bt *Sipcmbeat) getCallID(dst, src []byte, callID sipsp.PField, encFlags *F
 	if bt.Config.UseCallIDAnonymization() && (len(src) > 0) {
 		// anonymize Call-ID
 		//anonymization.DbgOn()
-		bt.anonymizer.CallId.PField = callID
+		bt.anonymizer.CallId.SetPField(&callID)
 		aCallId, err := bt.anonymizer.CallId.Anonymize(dst, src)
 		if err != nil {
 			return nil, fmt.Errorf("Call-ID field processing error: %w", err)
@@ -738,7 +743,7 @@ func (bt *Sipcmbeat) getEncContent(
 
 	if bt.Config.UseAnonymization() && (len(src) > 0) {
 		// anonymize src, the same way as Call-ID
-		bt.anonymizer.CallId.PField = content
+		bt.anonymizer.CallId.SetPField(&content)
 		aContent, err := bt.anonymizer.CallId.Anonymize(dst, src)
 		if err != nil {
 			return nil, false,

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/go-sourcemap/sourcemap v2.1.3+incompatible // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
-	github.com/intuitivelabs/anonymization v1.3.0
+	github.com/intuitivelabs/anonymization v1.4.0
 	github.com/intuitivelabs/calltr v1.1.9
 	github.com/intuitivelabs/counters v0.3.1
 	github.com/intuitivelabs/sipcallmon v0.8.12

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/go-sourcemap/sourcemap v2.1.3+incompatible // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
-	github.com/intuitivelabs/anonymization v1.4.0
+	github.com/intuitivelabs/anonymization v1.4.1
 	github.com/intuitivelabs/calltr v1.1.9
 	github.com/intuitivelabs/counters v0.3.1
 	github.com/intuitivelabs/sipcallmon v0.8.12

--- a/go.sum
+++ b/go.sum
@@ -409,6 +409,10 @@ github.com/intuitivelabs/anonymization v1.3.0 h1:sKV42Gyn6JeKWZ9nm++jeIb2mNOoCBh
 github.com/intuitivelabs/anonymization v1.3.0/go.mod h1:dXjVv/m2YD94lEYSZvbPGxxTaT4c3L8UL6TdaTMq6RY=
 github.com/intuitivelabs/anonymization v1.4.0 h1:0WVnPyn1EP0bc3QJezIAulfT918go/9XIrMVfHspFcQ=
 github.com/intuitivelabs/anonymization v1.4.0/go.mod h1:dXjVv/m2YD94lEYSZvbPGxxTaT4c3L8UL6TdaTMq6RY=
+github.com/intuitivelabs/anonymization v1.4.1-0.20220324141834-27bfd2e93465 h1:Kpe71YPVt3D2103l8ZUhGqZUQqVIDURi43AyO8iWwW8=
+github.com/intuitivelabs/anonymization v1.4.1-0.20220324141834-27bfd2e93465/go.mod h1:dXjVv/m2YD94lEYSZvbPGxxTaT4c3L8UL6TdaTMq6RY=
+github.com/intuitivelabs/anonymization v1.4.1 h1:YpXQPWboKFjo7BubtboK6v/YwB5Yqhl48lpuIbMjKQc=
+github.com/intuitivelabs/anonymization v1.4.1/go.mod h1:dXjVv/m2YD94lEYSZvbPGxxTaT4c3L8UL6TdaTMq6RY=
 github.com/intuitivelabs/bytescase v1.0.2-0.20210217091653-e8baf7a3651d/go.mod h1:Gr+B79bV8+mDKvYr4hja6qPVHtYG4Knem0K8gzZKHHU=
 github.com/intuitivelabs/bytescase v1.0.2 h1:Yz2aO9cw3Erdnyb9k7/SS/ckFkOG8KWr4UcgUxWjnqE=
 github.com/intuitivelabs/bytescase v1.0.2/go.mod h1:Gr+B79bV8+mDKvYr4hja6qPVHtYG4Knem0K8gzZKHHU=

--- a/go.sum
+++ b/go.sum
@@ -407,6 +407,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/intuitivelabs/anonymization v1.3.0 h1:sKV42Gyn6JeKWZ9nm++jeIb2mNOoCBhn4JBa3vjStZ8=
 github.com/intuitivelabs/anonymization v1.3.0/go.mod h1:dXjVv/m2YD94lEYSZvbPGxxTaT4c3L8UL6TdaTMq6RY=
+github.com/intuitivelabs/anonymization v1.4.0 h1:0WVnPyn1EP0bc3QJezIAulfT918go/9XIrMVfHspFcQ=
+github.com/intuitivelabs/anonymization v1.4.0/go.mod h1:dXjVv/m2YD94lEYSZvbPGxxTaT4c3L8UL6TdaTMq6RY=
 github.com/intuitivelabs/bytescase v1.0.2-0.20210217091653-e8baf7a3651d/go.mod h1:Gr+B79bV8+mDKvYr4hja6qPVHtYG4Knem0K8gzZKHHU=
 github.com/intuitivelabs/bytescase v1.0.2 h1:Yz2aO9cw3Erdnyb9k7/SS/ckFkOG8KWr4UcgUxWjnqE=
 github.com/intuitivelabs/bytescase v1.0.2/go.mod h1:Gr+B79bV8+mDKvYr4hja6qPVHtYG4Knem0K8gzZKHHU=

--- a/sipcmbeat_anonym_file_test.yml
+++ b/sipcmbeat_anonym_file_test.yml
@@ -6,7 +6,7 @@ sipcmbeat:
   # (very) verbose parser/ capture
   verbose: false
   # general log level: BUG -3, CRIT -2; ERR -1; WARN 0, NOTICE 1, INFO 2, DBG 3
-  log_level: 2
+  log_level: 3
   # log message options, flags:
   #    short filename:line - 1, long - 2, time stamp:  - 4,
   #    back trace short - 8, long - 16
@@ -103,7 +103,7 @@ sipcmbeat:
   encryption_salt: 1e22c6fd-7372-4429-a4e4-c39275a95f19
   # turn on/off ip address encryption, default off
   # (requires a set encryption_passphrase or encryption_key)
-  encrypt_ip_addresses: false
+  encrypt_ip_addresses: true
   # turn on/off URIs encryption, default off
   # (requires a set encryption_passphrase or encryption_key)
   encrypt_uris: true 


### PR DESCRIPTION
- decoupled key derivation; either `anonymization.GenerateAllKeysWithPassphrase()`
or `anonymization.GenerateAllKeysWithHexMasterKey()` are used to derive
all the keying material;
- keys are updated for the `Anonymizer` object using:
   ```
    if _, err := bt.anonymizer.UpdateKeys(anonymization.Keys[:]); err != nil {
        ...
    }
    ```
- anonymization is done using the `Anonymizer` object methods